### PR TITLE
Populate library.properties url field

### DIFF
--- a/sensortemp/library.properties
+++ b/sensortemp/library.properties
@@ -5,5 +5,5 @@ maintainer=Eduardo Cáceres de la Calle <edcaceres95@hotmail.com>
 sentence=Gets temperature from a temperature sensor, in ºC or ºF
 paragraph=This library allows an Arduino board to get the temperature provided by a low voltage tamperatura sensor (TMP36). It returns it in either ºC or ºF.
 category=Display
-url=*
+url=https://github.com/eduherminio/sensortemp
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.